### PR TITLE
解决IE低版本浏览器未开启Dev Tools时，无法访问console对象的问题

### DIFF
--- a/src/createLogger.js
+++ b/src/createLogger.js
@@ -1,4 +1,4 @@
-const attr = 'info' in console ? 'info' : "log"
+const attr = typeof console !== 'undefined' && 'info' in console ? 'info' : 'log'
 const pad = num => ('0' + num).slice(-2)
 const identity = obj => obj
 


### PR DESCRIPTION
IE 9浏览器在从未开启过开发者工具时，将无法访问console对象。