### PR TITLE
Optimize

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "ts-jest": "^24.0.2",
     "ts-node": "^8.3.0",
     "tslint": "^5.19.0",
+    "tslint-config-prettier": "^1.18.0",
+    "tslint-config-standard": "^8.0.1",
     "typescript": "^3.5.3"
   }
 }

--- a/src/createLogger.ts
+++ b/src/createLogger.ts
@@ -1,59 +1,77 @@
 /**
  * createLogger
  */
-import { Pad, Filter, LoggerCreator, LogInfo, Action } from './index'
+import { Pad, Filter, LoggerCreator, LogInfo } from "./index";
 
-const attr: string = typeof console !== 'undefined' && 'info' in console ? 'info' : 'log'
-const pad: Pad = num => ('0' + num).slice(-2)
+const createLogger: LoggerCreator = <S extends object>({
+  name = undefined,
+  filter = undefined
+} = {}) => {
+  const pad: Pad = num => ("0" + num).slice(-2);
+  const identity: Filter<S> = obj => obj;
+  filter = typeof filter === "function" ? filter : identity;
 
-const createLogger: LoggerCreator = <S extends object>({ name, filter }) => {
-    const identity: Filter<S> = obj => obj 
-    filter = typeof filter === 'function' ? filter : identity
-    
-    let logInfo: LogInfo<S> = data => {
-        data = filter(data)
-        const {
-            actionType,
-            actionPayload,
-            previousState,
-            currentState,
-            start = new Date(),
-            end = new Date(),
-            isAsync
-        } = data
-        const formattedTime: string = `${ start.getHours() }:${ pad(start.getMinutes()) }:${ pad(start.getSeconds()) }`
-        const takeTime: number = end.getTime() - start.getTime()
-        const message: string = `${ name || 'ROOT' }: action-type [${ actionType }] @ ${ formattedTime } in ${ takeTime }ms, ${isAsync ? 'async' : 'sync'}`
+  let logInfo: LogInfo<S> = data => {
+    const attr: string =
+      typeof console !== "undefined" && typeof console.info !== "undefined"
+        ? "info"
+        : "log";
+    data = filter(data);
+    const {
+      actionType,
+      actionPayload,
+      previousState,
+      currentState,
+      start,
+      end
+    } = data;
+    const formattedTime: string = `${start.getHours()}:${pad(
+      start.getMinutes()
+    )}:${pad(start.getSeconds())}`;
+    const takeTime: number = end.getTime() - start.getTime();
+    const message: string = `${name ||
+      "ROOT"}: action-type [${actionType}] @ ${formattedTime} in ${takeTime}ms}`;
 
-        try {
-            console.groupCollapsed(message)
-        } catch (e) {
-            try {
-                console.group(message)
-            } catch (e) {
-                console.log(message)
-            }
-        }
-
-        if (attr === 'log') {
-            console[attr](actionPayload)
-            console[attr](previousState)
-            console[attr](currentState)
-        } else {
-            console[attr](`%c action-payload`, `color: #03A9F4; font-weight: bold`, actionPayload)
-            console[attr](`%c prev-state`, `color: #9E9E9E; font-weight: bold`, previousState)
-            console[attr](`%c next-state`, `color: #4CAF50; font-weight: bold`, currentState)
-        }
-
-        try {
-            console.groupEnd()
-        } catch (e) {
-            console.log('-- log end --')
-        }
-
+    try {
+      console.groupCollapsed(message);
+    } catch (e) {
+      try {
+        console.group(message);
+      } catch (e) {
+        console.log(message);
+      }
     }
 
-    return logInfo
-}
+    if (attr === "log") {
+      console[attr](actionPayload);
+      console[attr](previousState);
+      console[attr](currentState);
+    } else {
+      console[attr](
+        `%c action-payload`,
+        `color: #03A9F4; font-weight: bold`,
+        actionPayload
+      );
+      console[attr](
+        `%c prev-state`,
+        `color: #9E9E9E; font-weight: bold`,
+        previousState
+      );
+      console[attr](
+        `%c next-state`,
+        `color: #4CAF50; font-weight: bold`,
+        currentState
+      );
+    }
 
-export default createLogger
+    try {
+      console.groupEnd();
+    } catch (e) {
+      console.log("-- log end --");
+    }
+  };
+
+  return logInfo;
+};
+
+export default createLogger;

--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -8,8 +8,9 @@ import {
   Dispatch,
   StateUpdator,
   Data,
-  Action,
-  CurringActions
+  Actions,
+  StateFromAS,
+  Currings
 } from "./index";
 
 import * as _ from "./util";
@@ -19,7 +20,7 @@ import * as _ from "./util";
  */
 const createStore: StoreCreator = <
   S extends object,
-  AS extends Record<string, Action<S>>
+  AS extends Actions<S & StateFromAS<AS>>
 >(
   actions,
   initialState
@@ -100,7 +101,7 @@ const createStore: StoreCreator = <
     return updateState(nextState);
   };
 
-  let curryActions: CurringActions<S, AS> = Object.keys(actions).reduce(
+  let curryActions: Partial<Currings<S, AS>> = Object.keys(actions).reduce(
     (obj, actionType) => {
       if (_.isFn(actions[actionType])) {
         obj[actionType] = actionPayload => dispatch(actionType, actionPayload);

--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -9,7 +9,8 @@ import {
   StateUpdator,
   Data,
   Action,
-  Curring
+  Curring,
+  CurringActions
 } from './index'
 
 import * as _ from './util'
@@ -96,7 +97,7 @@ const createStore: StoreCreator = <S extends object, AS extends Record<string, A
     return updateState(nextState)
   }
 
-  let curryActions: Partial<Curring<S, AS>> = Object.keys(actions).reduce((obj, actionType) => {
+  let curryActions: CurringActions<S, AS> = Object.keys(actions).reduce((obj, actionType) => {
     if (_.isFn(actions[actionType])) {
       obj[actionType] = actionPayload => dispatch(actionType, actionPayload)
     }

--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -9,74 +9,77 @@ import {
   StateUpdator,
   Data,
   Action,
-  Curring,
   CurringActions
-} from './index'
+} from "./index";
 
-import * as _ from './util'
+import * as _ from "./util";
 
 /**
  * createStore
  */
-const createStore: StoreCreator = <S extends object, AS extends Record<string, Action<S>>>(actions, initialState) => {
+const createStore: StoreCreator = <
+  S extends object,
+  AS extends Record<string, Action<S>>
+>(
+  actions,
+  initialState
+) => {
   if (!_.isObj(actions)) {
-    throw new Error(`Expected first argument to be an object`)
+    throw new Error(`Expected first argument to be an object`);
   }
 
-  let listeners: Listener<S>[] = []
+  let listeners: Listener<S>[] = [];
   let subscribe: Subscribe<S> = (listener: Listener<S>) => {
-    listeners.push(listener)
+    listeners.push(listener);
     return () => {
-      let index = listeners.indexOf(listener)
+      let index = listeners.indexOf(listener);
       if (index !== -1) {
-        listeners.splice(index, 1)
+        listeners.splice(index, 1);
+      } else {
+        console.warn(
+          "You want to unsubscribe a nonexistent listener. Maybe you had unsubscribed it"
+        );
       }
-    }
-  }
+    };
+  };
 
   let publish: Publish<S> = data => {
-    listeners.forEach(listener => listener(data))
-  }
+    listeners.forEach(listener => listener(data));
+  };
 
-  let currentState: S = initialState
+  let currentState: S = initialState;
 
-  let getState = () => currentState
+  let getState = () => currentState;
   let replaceState: ReplaceState<S> = (nextState, data, silent) => {
-    if (data && data.isAsync) {
-      // merge currentState and nextState to make sure all state is new
-      currentState = {
-        ...currentState,
-        ...nextState,
-      }
-    } else {
-      currentState = nextState
-    }
+    currentState = nextState;
     if (!silent) {
-      publish(data)
+      publish(data);
     }
-  }
+  };
 
-  let isDispatching: boolean = false
+  let isDispatching: boolean = false;
   let dispatch: Dispatch<S> = (actionType, actionPayload) => {
     if (isDispatching) {
-      throw new Error(`store.dispatch(actionType, actionPayload): handler may not dispatch`)
+      throw new Error(
+        `store.dispatch(actionType, actionPayload): handler may not dispatch`
+      );
     }
 
-    let start: Date = new Date()
-    let nextState: S = currentState
+    let start: Date = new Date();
+    let nextState: S = currentState;
     try {
-      isDispatching = true
-      nextState = actions[actionType](currentState, actionPayload)
+      isDispatching = true;
+      nextState = actions[actionType](currentState, actionPayload);
     } catch (error) {
-      throw error
+      throw error;
     } finally {
-      isDispatching = false
+      isDispatching = false;
     }
 
-    let isAsync: boolean = false
+    let isAsync: boolean = false;
     let updateState: StateUpdator<S> = nextState => {
       if (nextState === currentState) {
-        return currentState
+        return currentState;
       }
 
       let data: Data<S> = {
@@ -87,22 +90,29 @@ const createStore: StoreCreator = <S extends object, AS extends Record<string, A
         actionPayload,
         previousState: currentState,
         currentState: nextState
+      };
+
+      replaceState(nextState, data);
+
+      return nextState;
+    };
+
+    return updateState(nextState);
+  };
+
+  let curryActions: CurringActions<S, AS> = Object.keys(actions).reduce(
+    (obj, actionType) => {
+      if (_.isFn(actions[actionType])) {
+        obj[actionType] = actionPayload => dispatch(actionType, actionPayload);
+      } else {
+        throw new Error(
+          `Action must be a function. accept ${actions[actionType]}`
+        );
       }
-
-      replaceState(nextState, data)
-
-      return nextState
-    }
-
-    return updateState(nextState)
-  }
-
-  let curryActions: CurringActions<S, AS> = Object.keys(actions).reduce((obj, actionType) => {
-    if (_.isFn(actions[actionType])) {
-      obj[actionType] = actionPayload => dispatch(actionType, actionPayload)
-    }
-    return obj
-  }, {})
+      return obj;
+    },
+    {}
+  );
 
   let store: Store<S, AS> = {
     actions: curryActions,
@@ -110,10 +120,10 @@ const createStore: StoreCreator = <S extends object, AS extends Record<string, A
     replaceState,
     dispatch,
     subscribe,
-    publish,
-  }
+    publish
+  };
 
-  return store
-}
+  return store;
+};
 
-export default createStore
+export default createStore;

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ import $createLogger from './createLogger'
  */
 export interface Action<S extends object, P = any> {
   (
-    state: S | undefined,
+    state: S,
     payload?: P
   ): S
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -286,10 +286,6 @@ export interface Store<S extends object, AS extends Actions<S>> {
   publish: Publish<S>
 }
 
-export type DeepPartial<T> = {
-  [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K]
-}
-
 /**
  * A *StoreCreator* can create a global Relite store that hold the state tree, 
  * state, and also create getter and setter, `dispatch` and currying `actions`, 
@@ -305,7 +301,7 @@ export type DeepPartial<T> = {
 export interface StoreCreator {
   <S extends object, AS extends Actions<S>>(
     actions: AS,
-    initialState?: DeepPartial<S>
+    initialState?: S
   ): Store<S, AS>
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,207 +1,202 @@
 /**
  * relite
- * 
+ *
  * A redux-like library for managing state with simpler api.
  */
-import $createStore from './createStore'
-import $createLogger from './createLogger'
+import $createStore from "./createStore";
+import $createLogger from "./createLogger";
 
 /** Action */
 
 /**
  * A function looks like a reducer of redux, but more simple and powerful.
- * 
+ *
  * An `Action` consist of `Action` type, `Action` payload, `Action` handler
  * and `Action` result. `Action` type is the identifier of this function.
- * `Action` handler is the body of this function. `Action` result is the 
+ * `Action` handler is the body of this function. `Action` result is the
  * result of function.
- * 
+ *
  * In each `Action`, change the attribute needed and retain another attribute.
  * Suggest to use `...state` accomplish it.
- * 
+ *
  * @template S The type of state to be held by the store.
  * @template P The type of `Payload` that used to change the state as a assist.
- * 
+ *
  * @param state A snapshoot of current state. Will create new state based
  * on it.
  * @param [payload] Some useful data help to create new state. So we can
  * set it optionally.
- * 
+ *
  * @returns  A new state created just now.
  */
 export interface Action<S extends object, P = any> {
-  (
-    state: S,
-    payload?: P
-  ): S
+  (state: S, payload?: P): S;
 }
 
 /**
  * The collection of `Action`.
- * 
+ *
  * @template S The type of state to be held by the store.
  */
-export type Actions<S extends object> = Record<string, Action<S>>
+export type Actions<S extends object> = Record<string, Action<S>>;
 
 /**
  * In Relite, before actions exported by `store` them must be currying from some
  * `Action` those looks like `(s: State, p?: Payload) => State` to a `CurryingAction`
  * that looks like `(p?: Payload) => State` firstly.
- * 
+ *
  * The actions consist of `Action` need map to the actions consist of `CurringAction`.
- * 
+ *
  * The code hint of actions and the `Payload` type hint will work after doing this.
- * 
+ *
  * @template S The type of state to be held by the store.
  * @template AS The type of actions consist of `Action`. It will be map to the actions
  * that store will export.
  */
 export type Curring<S extends object, AS> = {
   readonly [k in keyof AS]: AS[k] extends Action<S, infer P>
-    ? (p?: P) => S : AS[k]
-}
+    ? (p?: P) => S
+    : AS[k];
+};
 
 /**
  * The cyrring `Actions`. Each `Action` in this will be optional.
- * 
+ *
  * @template S The type of state to be held by the store.
  * @template AS The type of actions consist of `Action`. It will be map to the actions
  * that store will export.
  */
-export type CurringActions<S extends object, AS extends Actions<S>>
-  = Partial<Curring<S, AS>>
+export type CurringActions<S extends object, AS extends Actions<S>> = Partial<
+  Curring<S, AS>
+>;
 
 /**
  * Infer the `Payload` data shape from an `Action`.
- * 
+ *
  * @template A The type of `Action` which we want to infer from.
  */
-export type PayloadFromAction<A> = A extends Action<object, infer P> ? P : A
+export type PayloadFromAction<A> = A extends Action<object, infer P> ? P : A;
 
 /** Data */
 
 /**
  * A object that record all information of once change of state.
- * 
+ *
  * It will be used when state will change while `dispatch()` or
  * `replaceState()` been called.
- * 
+ *
  * @template S The type of state to be held by the store.
  */
 export interface Data<S extends object> {
   /**
    * The identifier `actionType` of `Action` of this change.
    */
-  actionType: string
+  actionType: string;
 
   /**
    * The additional `Payload` data of a change from the `Action` of this
    * change.
    */
-  actionPayload: PayloadFromAction<Action<S>>
+  actionPayload: PayloadFromAction<Action<S>>;
 
   /**
    * The snapshoot of state before this change. The state that passed into
    * `Action`.
    */
-  previousState: S
+  previousState: S;
   /**
-   * The state will be after this change. The state that returned from 
+   * The state will be after this change. The state that returned from
    * `Action`.
    */
-  currentState: S
+  currentState: S;
   /**
    * The start time of this change occur.
    */
-  start: Date
+  start: Date;
   /**
    * The finished time of this change occur.
    */
-  end: Date
+  end: Date;
   /**
    * If the result of `Action` is a Promise.
    */
-  isAsync: boolean
+  isAsync: boolean;
 }
 
 /** Store */
 
 /**
  * An addit of store to add listener which listen the state change.
- * 
+ *
  * @template S The type of state to be held by the store.
  */
 export interface Subscribe<S extends object> {
-  (listener: Listener<S>): () => void
+  (listener: Listener<S>): () => void;
 }
 
 /**
  * An callback will been called when state has changed which has been add by
  * `subscribe()`. The state change information, `Data`, will been passed in
  * when call it.
- * 
+ *
  * @template S The type of state to be held by the store.
- * 
+ *
  * @param [data] The data object that record the change of once `Action` has
  * been called by `dispatch()`.
  */
 export interface Listener<S extends object> {
-  (data?: Data<S>): any
+  (data?: Data<S>): any;
 }
 
 /**
  * An broadcast function which will call all listener added before. The
  * parameter `Data` passed into listener is it's parameter `Data`. So we
  * do not know if this `Data` really occur.
- * 
+ *
  * @template S The type of state to be held by the store.
  */
 export interface Publish<S extends object> {
-  (data: Data<S>): void
+  (data: Data<S>): void;
 }
 
 /**
  * A setter of state which recover previous state forcedly. It may make
  * the state change uncertainly.
- * 
+ *
  * @template S The type of state to be held by the store.
  */
 export interface ReplaceState<S extends object> {
-  (
-    nextState: S,
-    data?: Data<S>,
-    silent?: boolean
-  ): void
+  (nextState: S, data?: Data<S>, silent?: boolean): void;
 }
 
 /**
  * A dispatcher that construct a new `Data` which record information of
  * new change of state by calling `Action` and call `updateState()` to
  * change state predictably.
- * 
+ *
  * @template S The type of state to be held by the store.
  */
 export interface Dispatch<S extends object> {
-  (actionType: string, actionPayload?: PayloadFromAction<Action<S>>): S
+  (actionType: string, actionPayload?: PayloadFromAction<Action<S>>): S;
 }
 
 /**
  * An state updator which get the final next state and call `replaceState()`
  * to change state.
- * 
+ *
  * @template S The type of state to be held by the store.
- * 
+ *
  * @param nextState all type which `Action` may return a state.
- * 
+ *
  * @returns The next state object.
  */
 export interface StateUpdator<S extends object> {
-  (nextState: S): S
+  (nextState: S): S;
 }
 
 /**
  * An object which export all API for change `state` and attach listener.
- * 
+ *
  * @template S The type of state to be held by the store.
  * @template AS The type of actions consist of `Action`.
  */
@@ -209,28 +204,28 @@ export interface Store<S extends object, AS extends Actions<S>> {
   /**
    * Contain all caller curring from `Action` passed in `createStore` and
    * `dispatch`. Could call dispatch whith mapped `Action` type.
-   * 
+   *
    * CurryingAction
    */
-  actions: CurringActions<S, AS>
+  actions: CurringActions<S, AS>;
 
   /**
    * Reads the state tree managed by the store.
    *
    * @returns The current state tree of your application that just can read.
    */
-  getState(): Readonly<S>
+  getState(): Readonly<S>;
 
   /**
    * Cover the state with the new state and the data passed in. It will
    * change the state unpredictably called by user directly.
-   * 
+   *
    * @param nextState It could be a state `object` will be the next state.
    * @param [data] The object that record al information of current change.
    * @param [silent] The signature indicate if we need to `publish()`. `true`
    * indicate not. `false` indicate yes. Default value is `false`.
    */
-  replaceState: ReplaceState<S>
+  replaceState: ReplaceState<S>;
   /**
    * Dispatches an Action. It is the only way to trigger a state change.
    *
@@ -239,7 +234,7 @@ export interface Store<S extends object, AS extends Actions<S>> {
    * to dispatch a Promise, you need pass in a Promise `Action`.
    *
    * @param actionType A plain string that is the identifier of an `Action`
-   * which representing “what changed”. It is a good idea to keep actions 
+   * which representing “what changed”. It is a good idea to keep actions
    * serializable so you can record and replay user sessions, or use the time
    * travelling `redux-devtools`. It is a requirement to use string constants
    * for Action types.
@@ -248,7 +243,7 @@ export interface Store<S extends object, AS extends Actions<S>> {
    *
    * @returns For convenience, the next state object you changed to.
    */
-  dispatch: Dispatch<S>
+  dispatch: Dispatch<S>;
 
   /**
    * Adds a change listener. It will be called any time an Action is
@@ -272,29 +267,29 @@ export interface Store<S extends object, AS extends Actions<S>> {
    * state by the time it exits.
    *
    * @param listener A callback to be invoked on every dispatch.
-   * 
+   *
    * @returns `unsubscribe` A function to remove this listener.
    */
-  subscribe: Subscribe<S>
+  subscribe: Subscribe<S>;
 
   /**
    * Broadcast all the listener attached before.
-   * 
+   *
    * @param data The state change information.The data object that need to
    * pass in all `Listener`.
    */
-  publish: Publish<S>
+  publish: Publish<S>;
 }
 
 /**
- * A *StoreCreator* can create a global Relite store that hold the state tree, 
- * state, and also create getter and setter, `dispatch` and currying `actions`, 
+ * A *StoreCreator* can create a global Relite store that hold the state tree,
+ * state, and also create getter and setter, `dispatch` and currying `actions`,
  * of it with `actions` and initialState. It support subscribe changes of state
  * implements with Observer design pattern.
- * 
+ *
  * `createStore(reducer, preloadedState)` exported from the Relite package,
  * from store creators.
- * 
+ *
  * @template S The type of state to be held by the store.
  * @template AS The type of actions those may be call by dispatch.
  */
@@ -302,94 +297,92 @@ export interface StoreCreator {
   <S extends object, AS extends Actions<S>>(
     actions: AS,
     initialState?: S
-  ): Store<S, AS>
+  ): Store<S, AS>;
 }
 
 /**
- * Create a global Relite store that hold the state tree, state, and also export 
- * getter and setter, `dispatch` and `actions`,of it with `actions` and 
+ * Create a global Relite store that hold the state tree, state, and also export
+ * getter and setter, `dispatch` and `actions`,of it with `actions` and
  * initialState. It support subscribe changes of state implements with Observer
  * design pattern.
- * 
+ *
  * @param actions An object who contains all the actions those can create state
  * and return it through passed previous state and `Payload` data.
  * @param [initialState] The initial state. You may optionally specify it.
- * 
+ *
  * @returns A Relite store that lets you read the state, dispatch actions and
  * subscribe to changes. It contains the setter of state, `replaceState`,
- * `dispatch` and all the `actions` whose have been encapsulated  with function 
+ * `dispatch` and all the `actions` whose have been encapsulated  with function
  * currying, the getter of state, `getState`, and the subscribe API,
  * `subscribe` and `publish`.
  */
-export const createStore: StoreCreator = $createStore
+export const createStore: StoreCreator = $createStore;
 
 /** Logger */
 
 /**
  * A *LoggerCreator* can create a logger which can record the information
  * when Relite running. The logger should been add to `store` as a listener.
- * 
- * `createLogger({name, filter})` exported from the Relite package from 
+ *
+ * `createLogger({name, filter})` exported from the Relite package from
  * logger creators.
- * 
+ *
  * @template S The type of state to be held by the store.
  */
 export interface LoggerCreator {
-  <S extends object>(
-    props?: LoggerProps<S>
-  ): LogInfo<S>
+  <S extends object>(props?: LoggerProps<S>): LogInfo<S>;
 }
 
 /**
  * Export a `logInfo` as a `listener` which record the information of the
  * relite state change.
- * 
+ *
  * @param props It consists of `name` and `filter`. `name` is the identifier
  * of this logger. `filter` is a middleware which will adapt `data`.
- * 
+ *
  * @returns A listener to record store state changed.
  */
-export const createLogger: LoggerCreator = $createLogger
+export const createLogger: LoggerCreator = $createLogger;
 
 /**
  * The arguments of LoggerCreator.
- * 
+ *
  * @template S The type of state to be held by the store.
  */
 export interface LoggerProps<S extends object> {
   /** the identifier of this logger */
-  name?: string
+  name?: string;
   /** a middleware which will adapt `data` */
-  filter?: Filter<S>
+  filter?: Filter<S>;
 }
 
 /**
  * A type of `listener` of Relite store.
- * 
+ *
  * @template S The type of state to be held by the store.
- * 
+ *
  * @param data A record of store state change.
  */
 export interface LogInfo<S extends object> {
-  (data: Data<S>): void
+  (data: Data<S>): void;
 }
 
 /**
  * A *Filter* is a middleware to sort `data`.
- * 
+ *
  * @template S The type of state to be held by the store.
- * 
+ *
  * @param data The `data` before sorting.
- * 
+ *
  * @returns The `data` after sorting.
  */
 export interface Filter<S extends object> {
-  (data: Data<S>): Data<S>
+  (data: Data<S>): Data<S>;
 }
 
 /**
  * A time string formatter.
  */
 export interface Pad {
-  (num: number): string
+  (num: number): string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -382,7 +382,7 @@ export interface LogInfo<S extends object> {
  * @param data The `data` before sorting.
  * 
  * @returns The `data` after sorting.
- **/
+ */
 export interface Filter<S extends object> {
   (data: Data<S>): Data<S>
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -3,33 +3,17 @@
  */
 
 interface IsFn {
-  (obj: any): boolean
-}
-
-interface IsThenable {
-  (obj: any): boolean
+  (obj: any): boolean;
 }
 
 interface IsObj {
-  (obj: any): boolean
+  (obj: any): boolean;
 }
 
-interface Identity {
-  (obj: any): any
-}
+export const isFn: IsFn = obj => {
+  return typeof obj === "function";
+};
 
-export const isFn: IsFn = (obj) => {
-	return typeof obj === 'function'
-}
-
-export const isThenable: IsThenable = (obj) => {
-	return obj != null && isFn(obj.then)
-}
-
-export const isObj: IsObj = (obj) => {
-	return Object.prototype.toString.call(obj) === '[object Object]'
-}
-
-export const identity: Identity = (obj) => {
-	return obj
-}
+export const isObj: IsObj = obj => {
+  return Object.prototype.toString.call(obj) === "[object Object]";
+};

--- a/test/createLogger.test.ts
+++ b/test/createLogger.test.ts
@@ -1,0 +1,89 @@
+import { createStore, createLogger, Action, Actions } from "../src/index";
+import * as actions from "./src/actions.helper";
+
+describe("test-createLogger", () => {
+  it("filter will should been called", () => {
+    let store = createStore(actions, { count: 0 });
+    let logInfo = createLogger({
+      name: "test",
+      filter: data => {
+        expect(data.actionType).toBe("INCREMENT");
+        return data;
+      }
+    });
+
+    jest.spyOn(global.console, "warn");
+    jest.spyOn(global.console, "info");
+    jest.spyOn(global.console, "log");
+
+    store.subscribe(logInfo);
+    store.actions.INCREMENT();
+
+    store.actions.INCREMENT();
+
+    expect(console.info).toBeCalled();
+  });
+
+  it("console should been called correctly", () => {
+    let store = createStore(actions, { count: 0 });
+    let logInfo = createLogger();
+
+    jest.spyOn(global.console, "info");
+
+    store.subscribe(logInfo);
+    store.actions.INCREMENT();
+
+    store.actions.INCREMENT();
+
+    expect(console.info).toBeCalled();
+  });
+
+  it("console.log should been called when console.group is unvaliable", () => {
+    let store = createStore(actions, { count: 0 });
+    let logInfo = createLogger();
+
+    global.console.groupCollapsed = () => {
+      throw new Error("test");
+    };
+
+    jest.spyOn(global.console, "log");
+    jest.spyOn(global.console, "group");
+    jest.spyOn(global.console, "groupEnd");
+
+    store.subscribe(logInfo);
+    store.actions.INCREMENT();
+
+    expect(console.group).toBeCalledTimes(1);
+    expect(console.groupEnd).toBeCalledTimes(1);
+
+    global.console.group = () => {
+      throw new Error("test");
+    };
+
+    store.actions.INCREMENT();
+
+    expect(console.log).toBeCalledTimes(1);
+
+    global.console.groupEnd = () => {
+      throw new Error("test");
+    };
+
+    store.actions.INCREMENT();
+
+    expect(console.log).toBeCalledTimes(3);
+  });
+
+  it("console.log should been called when console.info is unvaliable", () => {
+    let store = createStore(actions, { count: 0 });
+    let logInfo = createLogger();
+
+    console.info = undefined as typeof console.log;
+
+    jest.spyOn(global.console, "log");
+
+    store.subscribe(logInfo);
+    store.actions.INCREMENT();
+
+    expect(console.log).toBeCalledTimes(5);
+  });
+});

--- a/test/createStore.test.ts
+++ b/test/createStore.test.ts
@@ -1,4 +1,4 @@
-import { createStore, Action } from '../src/index'
+import { createStore, createLogger, Action } from '../src/index'
 import * as actions from './src/actions.helper'
 
 describe('test-createStore', () => {
@@ -102,4 +102,9 @@ describe('test-createStore', () => {
 		createStore(actions, state)
 	})
 
+	it('listener should not been called after unsubscribe', () => {
+		let store = createStore(actions, { count: 1, test: 1 })
+
+		
+	})
 })

--- a/test/createStore.test.ts
+++ b/test/createStore.test.ts
@@ -1,4 +1,4 @@
-import { createStore } from '../src/index'
+import { createStore, Action } from '../src/index'
 import * as actions from './src/actions.helper'
 
 describe('test-createStore', () => {
@@ -83,6 +83,23 @@ describe('test-createStore', () => {
 		unsubscribe()
 		store.actions.INCREMENT()
 		expect(listener).toBeCalledTimes(1)
+	})
+
+	it('state type is correct', () => {
+		type ObjectAlias = object;
+
+		interface State extends ObjectAlias {
+			location?: object
+		}
+
+		let state: State = {}
+
+		const IIIII: Action<State> = (state) => state
+		let actions = {
+			IIIII
+		}
+
+		createStore(actions, state)
 	})
 
 })

--- a/test/createStore.test.ts
+++ b/test/createStore.test.ts
@@ -2,11 +2,12 @@ import { createStore, Action, Actions } from "../src/index";
 import * as actions from "./src/actions.helper";
 import * as errorAction from "./src/actions.error";
 import * as changeAction from "./src/actions.change";
+import * as anyActions from './src/actions.any'
 
 describe("test-createStore", () => {
   it("actions should be object", () => {
     try {
-      createStore(undefined as Actions<{}>);
+      createStore(undefined as Actions<Action<{}>>);
     } catch (e) {
       expect((e as Error).message).toMatch(
         "Expected first argument to be an object"
@@ -178,4 +179,10 @@ describe("test-createStore", () => {
 
     expect(listener).toBeCalledTimes(1);
   });
+
+  it("defense `any` type", () => {
+    let store = createStore(anyActions, { count: 1 })
+    store.getState()
+    store.actions.Payload()
+  })
 });

--- a/test/src/actions.any.ts
+++ b/test/src/actions.any.ts
@@ -1,0 +1,18 @@
+export const ANY = (state) => {
+  let a
+  return a
+}
+
+export const STANDARD = state => {
+  return {
+    bb: 'bb'
+  }
+}
+
+export const Payload = (state, payload?: {
+  cc: number
+}) => {
+  return {
+    cc: 'bb'
+  }
+}

--- a/test/src/actions.change.ts
+++ b/test/src/actions.change.ts
@@ -1,0 +1,10 @@
+export const NOCHANGE = (state) => {
+  return state
+}
+
+export const CHANGE = state => {
+  return {
+    ...state,
+    count: state.count
+  }
+}

--- a/test/src/actions.error.ts
+++ b/test/src/actions.error.ts
@@ -1,0 +1,8 @@
+export const TEST = (state, store) => {
+  store.actions.CHECK()
+  return state
+}
+
+export const CHECK = state => {
+  return state
+}

--- a/test/src/actions.helper.ts
+++ b/test/src/actions.helper.ts
@@ -8,7 +8,7 @@ export let INCREMENT = (state) => {
   }
 }
 
-export let DECREMENT = (state = { count: 0 }) => {
+export let DECREMENT = (state) => {
   let count = state.count - 1
   return {
     ...state,
@@ -16,14 +16,11 @@ export let DECREMENT = (state = { count: 0 }) => {
   }
 }
 
-export let EXEC_BY = ({ count = 0, ...rest } = {}, input = 0) => {
+export let EXEC_BY = (state, input) => {
   let value = Number(input)
-  return isNaN(value) ? {
-    count,
-    ...rest
-  } : {
-    ...rest,
-    count: count + value
+  return isNaN(value) ? state : {
+    ...state,
+    count: state.count + value
   }
 }
 


### PR DESCRIPTION
- Don't support async `action` and `action` which return other `action`.
- Add defense code that `action` maybe return an `any` type value. Although it is incorrect way we still should defend it.
- Add test use case to cover. (Now each test item is 100%)